### PR TITLE
Add HTTPS cert & uptime checks for magerewards.

### DIFF
--- a/extra/conf.d/http_check.d/conf.yaml
+++ b/extra/conf.d/http_check.d/conf.yaml
@@ -84,3 +84,15 @@ instances:
     url: http://livethe.pinpoint.life/xQ8q6ogk
     timeout: 1
     min_collection_interval: 180
+  - name: MageRewards Account SignIn
+    url: https://account.magerewards.com/
+    timeout: 1
+    min_collection_interval: 180
+    days_warning: 60
+    days_critical: 14
+  - name: MageRewards CDN
+    url: https://cdn.magerewards.com/
+    timeout: 1
+    min_collection_interval: 180
+    days_warning: 60
+    days_critical: 14


### PR DESCRIPTION
Covers account.magerewards.com and cdn.magerewrads.com

https://smileio.atlassian.net/browse/SRE-232